### PR TITLE
Choice for Code Quality, Code Coverage and CI/CD & some fixes

### DIFF
--- a/src/Commands/MakePackage.php
+++ b/src/Commands/MakePackage.php
@@ -114,6 +114,9 @@ class MakePackage extends Command
         $this->createComposer($packagePath);
         $this->createServiceProvider($packagePath);
         $this->createTestCase($packagePath);
+        $this->createContinousIntegrationService($packagePath);
+        $this->createCodeQualityService($packagePath);
+        $this->createCodeCoverageService($packagePath);
 
         $this->callSilent('package:add', [
             'name'                  => $this->packageName,
@@ -174,9 +177,6 @@ class MakePackage extends Command
         $this->files->put($path.'/readme.md', $this->buildFile('readme'));
         $this->files->put($path.'/LICENSE.md', $this->buildFile('LICENSE'));
         $this->files->put($path.'/CONTRIBUTING.md', $this->buildFile('CONTRIBUTING'));
-        $this->files->put($path.'/.travis.yml', $this->buildFile('.travis'));
-        $this->files->put($path.'/.styleci.yml', $this->buildFile('.styleci'));
-        $this->files->put($path.'/codecov.yml', $this->buildFile('codecov'));
         $this->files->put($path.'/phpunit.xml', $this->buildFile('phpunit'));
         $this->files->put($path.'/.gitignore', $this->buildFile('.gitignore'));
         $this->info('Common files created successfully!');
@@ -216,6 +216,66 @@ class MakePackage extends Command
         );
 
         $this->info('Test Case created sucessfully!');
+    }
+
+    /**
+     * @param $path
+     * 
+     * @return void
+     */
+    protected function createContinousIntegrationService($path)
+    {
+        $CI = $this->choice('What CI/CD service you want to use?', ['TravisCI'], 'TravisCI');
+
+        switch($CI) {
+            case 'TravisCI':
+                $this->files->put($path.'/.travis.yml', $this->buildFile('.travis'));
+                break;
+            default:
+                break;
+        }
+
+        $this->info('CI/CD provider was set up!');
+    }
+
+    /**
+     * @param $path
+     * 
+     * @return void
+     */
+    protected function createCodeQualityService($path)
+    {
+        $CQ = $this->choice('What code quality service you want to use?', ['StyleCI'], 'StyleCI');
+
+        switch($CQ) {
+            case 'StyleCI':
+                $this->files->put($path.'/.styleci.yml', $this->buildFile('.styleci'));
+                break;
+            default:
+                break;
+        }
+
+        $this->info('Code quality provider was set up!');
+    }
+
+    /**
+     * @param $path
+     * 
+     * @return void
+     */
+    protected function createCodeCoverageService($path)
+    {
+        $CC = $this->choice('What code coverage service you want to use?', ['Codecov'], 'Codecov');
+
+        switch($CC) {
+            case 'Codecov':
+                $this->files->put($path.'/codecov.yml', $this->buildFile('codecov'));
+                break;
+            default:
+                break;
+        }
+
+        $this->info('Code coverage provider was set up!');
     }
 
     /**

--- a/src/Commands/MakePackage.php
+++ b/src/Commands/MakePackage.php
@@ -108,12 +108,12 @@ class MakePackage extends Command
         }
 
         $this->createDirectories($packagePath);
-
         $this->createCommonFiles($packagePath);
 
         $this->createComposer($packagePath);
         $this->createServiceProvider($packagePath);
         $this->createTestCase($packagePath);
+
         $this->createContinousIntegrationService($packagePath);
         $this->createCodeQualityService($packagePath);
         $this->createCodeCoverageService($packagePath);
@@ -129,6 +129,8 @@ class MakePackage extends Command
 
     /**
      * Checks for needed input and prints it out.
+     * 
+     * @return void
      */
     public function checkForInputs()
     {
@@ -148,7 +150,9 @@ class MakePackage extends Command
     }
 
     /**
-     * @param $path
+     * @param string $path
+     * 
+     * @return void
      */
     protected function createDirectories($path)
     {
@@ -159,8 +163,10 @@ class MakePackage extends Command
 
         $this->files->makeDirectory($path);
         $this->info('Package directory created successfully!');
+
         $this->files->makeDirectory($path.'/src');
         $this->info('Source directory created successfully!');
+
         $this->files->makeDirectory($path.'/tests');
         $this->info('Tests directory created successfully!');
     }
@@ -168,9 +174,11 @@ class MakePackage extends Command
     /**
      * Create common files.
      *
-     * @param $path
+     * @param string $path
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * 
+     * @return void
      */
     protected function createCommonFiles($path)
     {
@@ -179,24 +187,30 @@ class MakePackage extends Command
         $this->files->put($path.'/CONTRIBUTING.md', $this->buildFile('CONTRIBUTING'));
         $this->files->put($path.'/phpunit.xml', $this->buildFile('phpunit'));
         $this->files->put($path.'/.gitignore', $this->buildFile('.gitignore'));
+
         $this->info('Common files created successfully!');
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * 
+     * @return void
      */
     protected function createComposer($path)
     {
         $this->files->put($path.'/composer.json', $this->buildFile('composer'));
+
         $this->info('Composer created successfully!');
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * 
+     * @return void
      */
     protected function createServiceProvider($path)
     {
@@ -208,6 +222,11 @@ class MakePackage extends Command
         $this->info('Service Provider created successfully!');
     }
 
+    /**
+     * @param string $path
+     * 
+     * @return void
+     */
     protected function createTestCase($path)
     {
         $this->files->put(
@@ -219,7 +238,7 @@ class MakePackage extends Command
     }
 
     /**
-     * @param $path
+     * @param string $path
      * 
      * @return void
      */
@@ -239,7 +258,7 @@ class MakePackage extends Command
     }
 
     /**
-     * @param $path
+     * @param string $path
      * 
      * @return void
      */
@@ -259,7 +278,7 @@ class MakePackage extends Command
     }
 
     /**
-     * @param $path
+     * @param string $path
      * 
      * @return void
      */
@@ -279,11 +298,11 @@ class MakePackage extends Command
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      *
-     * @return MakePackage
+     * @return \Naoray\LaravelPackageMaker\Commands\MakePackage
      */
     protected function buildFile($name)
     {
@@ -299,7 +318,7 @@ class MakePackage extends Command
      *
      * @param string $stub
      *
-     * @return $this
+     * @return \Naoray\LaravelPackageMaker\Commands\MakePackage
      */
     protected function replaceNamespaces(&$stub)
     {
@@ -317,7 +336,7 @@ class MakePackage extends Command
      *
      * @param string $stub
      *
-     * @return $this
+     * @return \Naoray\LaravelPackageMaker\Commands\MakePackage
      */
     protected function replaceNames(&$stub)
     {
@@ -335,7 +354,7 @@ class MakePackage extends Command
      *
      * @param $stub
      *
-     * @return mixed
+     * @return string
      */
     protected function replaceCredentials(&$stub)
     {
@@ -391,7 +410,7 @@ class MakePackage extends Command
     /**
      * Determine if the class already exists.
      *
-     * @param $path
+     * @param string $path
      *
      * @return bool
      */


### PR DESCRIPTION
There have been some method comments that needed types to be set and the returns fixed.
Also, instead of just copying `.travis.yml`, `.styleci.yml` and `codecov.yml`, i have decided that a `->choice()` method would be good, since some prefer CircleCI over Travis, or CodeClimate over StyleCI, and so forth. So, anytime you want to add a new service, you have to add it in the switch case.

Also, the `readme.md` needs changed, but i think that'll be on a new release.

If you prefer any other method about coding style, feel free to edit the PR's changes, i always promote the fact that everyone's coding style is different, and it should be like that, so always make the changes that suits you the best. 😁 

CircleCI is coming soon, need to make some tests before adding it. Now i have prepared the playground. 🎲 