### PR TITLE
Fix: test breaking due to incorrect string appended to the test output

### DIFF
--- a/tests/Feature/ReplaceTest.php
+++ b/tests/Feature/ReplaceTest.php
@@ -5,7 +5,7 @@ namespace Naoray\LaravelPackageMaker\Tests\Feature;
 use Naoray\LaravelPackageMaker\Tests\TestCase;
 use Naoray\LaravelPackageMaker\Traits\InteractsWithTerminal;
 
-class ResplaceTest extends TestCase
+class ReplaceTest extends TestCase
 {
     use InteractsWithTerminal;
 

--- a/tests/Feature/ResplaceTest.php
+++ b/tests/Feature/ResplaceTest.php
@@ -17,7 +17,7 @@ class ResplaceTest extends TestCase
         $old = 'TestPackageNamespace';
         $new = 'NewPackageNamespace';
 
-        $this->runCommand('echo \'# '.$old . '\c'.'\' > '.$fileName, $path);
+        $this->runCommand('/bin/echo -n \'# '.$old.'\' >> '.$fileName, $path);
 
         $this->runReplaceCommand($path, $old, $new);
 

--- a/tests/Feature/ResplaceTest.php
+++ b/tests/Feature/ResplaceTest.php
@@ -17,7 +17,7 @@ class ResplaceTest extends TestCase
         $old = 'TestPackageNamespace';
         $new = 'NewPackageNamespace';
 
-        $this->runCommand('echo -n \'# '.$old.'\' >> '.$fileName, $path);
+        $this->runCommand('echo \'# '.$old . '\c'.'\' > '.$fileName, $path);
 
         $this->runReplaceCommand($path, $old, $new);
 


### PR DESCRIPTION
When running the test, the string `-n # TestPackageNamespace` is appended to the dummy test output file `ReplaceTest.md`. Here the `-n ` is not supposed to be here. Also instead of creating only one entry in the file, the replaced text is appended to the dummy file.

On the first run, we will get a failed test with the below output.

```
-n # NewPackageNamespace
```

On next run, this will become:

```
-n # NewPackageNamespace
-n # NewPackageNamespace
```

Here instead of using `-n` we are using `\c` and also instead of appending, we are replacing the content of the file.